### PR TITLE
Remove unused badges from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
 # Pysio's Home
-![Vue-blog](https://socialify.git.ci/pysio2007/Vue-blog/image?description=1&descriptionEditable=Pysio%27s%20Home%20%E4%B8%80%E4%B8%AA%E6%B8%A9%E6%9A%96%E7%9A%84%E5%AE%B6&forks=1&language=1&name=1&owner=1&pattern=Circuit%20Board&pulls=1&stargazers=1&theme=Auto)
-[![note build](https://github.com/pysio2007/Vue-blog/actions/workflows/bulid-server.yml/badge.svg)](https://github.com/pysio2007/Vue-blog/actions/workflows/bulid-server.yml)
 [![Build Docker Image](https://github.com/pysio2007/Vue-blog/actions/workflows/bulid-docker.yml/badge.svg)](https://github.com/pysio2007/Vue-blog/actions/workflows/bulid-docker.yml)
 [![wakatime](https://wakatime.com/badge/user/a8344004-6b9a-4a56-8b71-e626b395781c/project/d910a3a5-e3e2-425e-be0f-175d36fa6d19.svg)](https://wakatime.com/badge/user/a8344004-6b9a-4a56-8b71-e626b395781c/project/d910a3a5-e3e2-425e-be0f-175d36fa6d19)     
 ## 关于本仓库


### PR DESCRIPTION
This pull request makes a minor update to the `README.md` file by removing the project banner image and the "note build" GitHub Actions badge. The main Docker build and Wakatime badges remain unchanged.Removed Vue-blog image and note build badge from README.